### PR TITLE
Add (mostly failing) test cases for ReferenceParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.15.2</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.11.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -84,6 +91,12 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
 			</plugin>
 		</plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
 			<groupId>pl.edu.icm</groupId>
 			<artifactId>cermine</artifactId>
 			<version>1.13</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/lib/cermine.jar</systemPath>
 		</dependency> 
 		
 		<dependency>

--- a/src/main/java/com/cerca/utils/ReferenceParser.java
+++ b/src/main/java/com/cerca/utils/ReferenceParser.java
@@ -8,14 +8,14 @@ import pl.edu.icm.cermine.bibref.model.BibEntry;
 import pl.edu.icm.cermine.bibref.model.BibEntryFieldType;
 import pl.edu.icm.cermine.exception.AnalysisException;
 
+import java.util.List;
+
 public class ReferenceParser {
 
-   
     private static CRFBibReferenceParser parser;
 
     static {
         try {
-            
             parser = CRFBibReferenceParser.getInstance();
         } catch (AnalysisException e) {
             System.err.println("CERMINE Model Error: " + e.getMessage());
@@ -46,14 +46,13 @@ public class ReferenceParser {
                 BibEntry bibEntry = parser.parseBibReference(cleanRef);
                 
                 // --- FIX: USE getAllFieldValues ---
-                java.util.List<String> authorList = bibEntry.getAllFieldValues(BibEntryFieldType.AUTHOR);
+                List<String> authorList = bibEntry.getAllFieldValues(BibEntryFieldType.AUTHOR);
                 
                 if (authorList != null && !authorList.isEmpty()) {
                     authors = String.join(", ", authorList);
                 }
 
                 title = bibEntry.getFirstFieldValue(BibEntryFieldType.TITLE);
-                
             } catch (Exception e) {
                 // Ignore, proceed to fallback
             }
@@ -64,7 +63,7 @@ public class ReferenceParser {
             title = cleanRef;
         }
 
-        return new ParsedData(clean(authors), clean(title));
+        return new ParsedData(authors, clean(title));
     }
 
     

--- a/src/test/java/com/cerca/utils/ReferenceParserTest.java
+++ b/src/test/java/com/cerca/utils/ReferenceParserTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReferenceParserTest {
     @ParameterizedTest
@@ -46,6 +46,16 @@ public class ReferenceParserTest {
                         "[20] B. Yetiştiren, I. Özsoy, M. Ayerdem, and E. Tüzün, “Evaluating the code quality of ai-assisted code generation tools: An empirical study on github copilot, amazon codewhisperer, and chatgpt,” arXiv preprint arXiv:2304.10778, 2023. [Online]. Available: https://arxiv.org/abs/2304.10778",
                         "Yetiştiren, B., Özsoy, I., Ayerdem, M., Tüzün, E.",
                         "Evaluating the code quality of ai-assisted code generation tools: An empirical study on github copilot, amazon codewhisperer, and chatgpt"
+                ),
+                Arguments.of(
+                        "[39] Charity Majors, Liz Fong-Jones, and George Miranda. Observability engineering. \" O’Reilly Media, Inc.\", 2022.",
+                        "Majors, Charity, Fong-Jones Liz, Miranda, George",
+                        "Observability engineering"
+                ),
+                Arguments.of(
+                        "[27] R. Cavalcante, L. Oliveira, and A. Santos, “Developers’ perceptions of ai programming assistants: A case study of copilot, chatgpt, and gemini,” in Proceedings of the 2025 International Conference on Software Maintenance and Evolution (ICSME). IEEE, 2025.",
+                        "Cavalcante, R., Oliveira, L., Santos, A.",
+                        "Developers’ perceptions of ai programming assistants: A case study of copilot, chatgpt, and gemini"
                 )
         );
     }

--- a/src/test/java/com/cerca/utils/ReferenceParserTest.java
+++ b/src/test/java/com/cerca/utils/ReferenceParserTest.java
@@ -1,0 +1,40 @@
+package com.cerca.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReferenceParserTest {
+    @ParameterizedTest
+    @MethodSource("referenceProvider")
+    void testAuthorExtraction(String input, String expectedAuthors) {
+        ReferenceParser.ParsedData result = ReferenceParser.parse(input);
+
+        assertEquals(expectedAuthors, result.authors);
+    }
+
+    static Stream<Arguments> referenceProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "[80] N. Rytilä, “Addressing end-to-end testing challenges with cypress,” 2025.",
+                        "Rytilä, N."
+                ),
+                Arguments.of(
+                        "[100] T. Zhang, Y. Liu, J. Gao, L. P. Gao, and J. Cheng, “Deep learning paper,” Ieee Software, vol. 37, no. 4, pp. 67–74, 2020.",
+                        "Zhang, T., Liu, Y., Gao, J., Gao, L. P., Cheng, J."
+                ),
+                Arguments.of(
+                        "[50] Martina Yvonne Feilzer. Doing mixed methods research pragmatically: Implications for the rediscovery of pragmatism as a research paradigm. Journal of mixed methods research, 4(1):6–16, 2010.",
+                        "Feilzer, Martina Yvonne"
+                ),
+                Arguments.of(
+                        "[20] B. Yetiştiren, I. Özsoy, M. Ayerdem, and E. Tüzün, “Evaluating the code quality of ai-assisted code generation tools: An empirical study on github copilot, amazon codewhisperer, and chatgpt,” arXiv preprint arXiv:2304.10778, 2023. [Online]. Available: https://arxiv.org/abs/2304.10778",
+                        "Yetiştiren, B., Özsoy, I., Ayerdem, M., Tüzün, E."
+                )
+        );
+    }
+}

--- a/src/test/java/com/cerca/utils/ReferenceParserTest.java
+++ b/src/test/java/com/cerca/utils/ReferenceParserTest.java
@@ -17,23 +17,35 @@ public class ReferenceParserTest {
         assertEquals(expectedAuthors, result.authors);
     }
 
+    @ParameterizedTest
+    @MethodSource("referenceProvider")
+    void testTitleExtraction(String input, String ignored, String expectedTitle) {
+        ReferenceParser.ParsedData result = ReferenceParser.parse(input);
+
+        assertEquals(expectedTitle, result.title);
+    }
+
     static Stream<Arguments> referenceProvider() {
         return Stream.of(
                 Arguments.of(
                         "[80] N. Rytilä, “Addressing end-to-end testing challenges with cypress,” 2025.",
-                        "Rytilä, N."
+                        "Rytilä, N.",
+                        "Addressing end-to-end testing challenges with cypress"
                 ),
                 Arguments.of(
                         "[100] T. Zhang, Y. Liu, J. Gao, L. P. Gao, and J. Cheng, “Deep learning paper,” Ieee Software, vol. 37, no. 4, pp. 67–74, 2020.",
-                        "Zhang, T., Liu, Y., Gao, J., Gao, L. P., Cheng, J."
+                        "Zhang, T., Liu, Y., Gao, J., Gao, L. P., Cheng, J.",
+                        "Deep learning paper"
                 ),
                 Arguments.of(
                         "[50] Martina Yvonne Feilzer. Doing mixed methods research pragmatically: Implications for the rediscovery of pragmatism as a research paradigm. Journal of mixed methods research, 4(1):6–16, 2010.",
-                        "Feilzer, Martina Yvonne"
+                        "Feilzer, Martina Yvonne",
+                        "Doing mixed methods research pragmatically: Implications for the rediscovery of pragmatism as a research paradigm"
                 ),
                 Arguments.of(
                         "[20] B. Yetiştiren, I. Özsoy, M. Ayerdem, and E. Tüzün, “Evaluating the code quality of ai-assisted code generation tools: An empirical study on github copilot, amazon codewhisperer, and chatgpt,” arXiv preprint arXiv:2304.10778, 2023. [Online]. Available: https://arxiv.org/abs/2304.10778",
-                        "Yetiştiren, B., Özsoy, I., Ayerdem, M., Tüzün, E."
+                        "Yetiştiren, B., Özsoy, I., Ayerdem, M., Tüzün, E.",
+                        "Evaluating the code quality of ai-assisted code generation tools: An empirical study on github copilot, amazon codewhisperer, and chatgpt"
                 )
         );
     }


### PR DESCRIPTION
Author and title extraction don't work super-well right now.
This PR adds a small number of failing test cases and provides a fix for one simple case
(needless removal of trailing dots in abbreviated author names).